### PR TITLE
feat!: reformat changelog output

### DIFF
--- a/.changeset/cuddly-carrots-train.md
+++ b/.changeset/cuddly-carrots-train.md
@@ -1,0 +1,5 @@
+---
+'@mheob/changeset-changelog': major
+---
+
+reformat the changelog output to displzy first the PR and user

--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -5,5 +5,6 @@ module.exports = {
 	...defaultConfig,
 	prompt: {
 		...defaultConfig.prompt,
+		allowEmptyScopes: true,
 	},
 };

--- a/src/getDependencyReleaseLine.ts
+++ b/src/getDependencyReleaseLine.ts
@@ -3,10 +3,7 @@ import type { GetDependencyReleaseLine, NewChangesetWithCommit } from '@changese
 
 import { errorMessage } from './utils';
 
-async function getDependencyReleaseLinks(
-	changesets: NewChangesetWithCommit[],
-	repository: string,
-): Promise<string> {
+async function getDependencyReleaseLinks(changesets: NewChangesetWithCommit[], repository: string) {
 	const changesetLinks = await Promise.all(
 		changesets.map(async (cs) => {
 			// istanbul ignore next: because of our mocked get-github-info -- @preserve

--- a/src/getReleaseLine.ts
+++ b/src/getReleaseLine.ts
@@ -91,7 +91,7 @@ function getUserLink(usersFromSummary: string[], user?: string) {
 					.trim()
 			: user;
 
-	return userLink ? `by ${userLink}` : undefined;
+	return userLink ? `(${userLink})` : '';
 }
 
 // add links to issue hints (fix #123) => (fix [#123](https://....))
@@ -120,12 +120,11 @@ export const getReleaseLine: GetReleaseLine = async (changeset, _type, options) 
 
 	const prMessage = pull ? `(${pull})` : '';
 	const commitMessage = commit ? `(${commit})` : '';
-	const userLinkMessage = userLink ?? '';
 	// istanbul ignore next: because of our mocked get-github-info -- @preserve
-	const printPrOrCommit = pull !== '' ? prMessage : commitMessage;
-	const suffix = printPrOrCommit.trim() ? ` --> ${printPrOrCommit.trim()} ${userLinkMessage}` : '';
+	const printPrOrCommit = (pull !== '' ? prMessage : commitMessage).trim();
+	const prefix = printPrOrCommit ? `${printPrOrCommit} ${userLink}: ` : '';
 
 	const futureLinesMessage = futureLines.map((line) => `  ${line}`).join('\n');
 
-	return `\n\n- ${firstLine}${suffix}\n${futureLinesMessage}`;
+	return `\n\n- ${prefix}${firstLine}\n${futureLinesMessage}`;
 };

--- a/src/getReleaseLine.ts
+++ b/src/getReleaseLine.ts
@@ -44,7 +44,7 @@ async function getGitHubLinks(
 	commit?: string,
 	commitFromSummary?: string,
 	prFromSummary?: number,
-): Promise<GithubLinks> {
+) {
 	let githubLinks: GithubLinks = { commit: undefined, pull: undefined, user: undefined };
 
 	if (prFromSummary) {
@@ -82,7 +82,7 @@ async function getGitHubLinks(
 	return githubLinks;
 }
 
-function getUserLink(usersFromSummary: string[], user?: string): string | undefined {
+function getUserLink(usersFromSummary: string[], user?: string) {
 	const userLink =
 		usersFromSummary.length > 0
 			? usersFromSummary
@@ -96,7 +96,7 @@ function getUserLink(usersFromSummary: string[], user?: string): string | undefi
 
 // add links to issue hints (fix #123) => (fix [#123](https://....))
 // thanks to https://github.com/svitejs/changesets-changelog-github-compact
-function linkifyIssue(line: string, repository: string): string {
+function linkifyIssue(line: string, repository: string) {
 	return line.replace(/(?<=\( ?(?:fix|fixes|resolves|see) )(#\d+)(?= ?\))/g, (issue) => {
 		return `[${issue}](https://github.com/${repository}/issues/${issue.slice(1)})`;
 	});

--- a/src/getReleaseLine.ts
+++ b/src/getReleaseLine.ts
@@ -118,8 +118,8 @@ export const getReleaseLine: GetReleaseLine = async (changeset, _type, options) 
 		.split('\n')
 		.map((line) => linkifyIssue(line.trimEnd(), options['repo']));
 
-	const prMessage = pull ? `(${pull})` : '';
-	const commitMessage = commit ? `(${commit})` : '';
+	const prMessage = pull ? `${pull}` : '';
+	const commitMessage = commit ? `${commit}` : '';
 	// istanbul ignore next: because of our mocked get-github-info -- @preserve
 	const printPrOrCommit = (pull !== '' ? prMessage : commitMessage).trim();
 	const prefix = printPrOrCommit ? `${printPrOrCommit} ${userLink}: ` : '';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -112,7 +112,7 @@ describe('getReplacedChangelog', () => {
 		);
 		const result = await getReleaseLine(changeset, 'minor', { repo: data.repo });
 		expect(result).toBe(
-			'\n\n- An awesome feature. --> ([#2](https://github.com/mheob/changeset-changelog/pull/2)) by [@mheob](https://github.com/mheob)\n',
+			'\n\n- [#2](https://github.com/mheob/changeset-changelog/pull/2) ([@mheob](https://github.com/mheob)): An awesome feature.\n',
 		);
 	});
 
@@ -120,7 +120,7 @@ describe('getReplacedChangelog', () => {
 		const changeset = getChangeset('An awesome feature.', data.commit);
 		const result = await getReleaseLine(changeset, 'minor', { repo: data.repo });
 		expect(result).toBe(
-			'\n\n- An awesome feature. --> ([#2](https://github.com/mheob/changeset-changelog/pull/2)) by [@mheob](https://github.com/mheob)\n',
+			'\n\n- [#2](https://github.com/mheob/changeset-changelog/pull/2) ([@mheob](https://github.com/mheob)): An awesome feature.\n',
 		);
 	});
 
@@ -128,7 +128,7 @@ describe('getReplacedChangelog', () => {
 		const changeset = getChangeset('An awesome feature, (resolves #9)', data.commit);
 		const result = await getReleaseLine(changeset, 'minor', { repo: data.repo });
 		expect(result).toBe(
-			'\n\n- An awesome feature, (resolves [#9](https://github.com/mheob/changeset-changelog/issues/9)) --> ([#2](https://github.com/mheob/changeset-changelog/pull/2)) by [@mheob](https://github.com/mheob)\n',
+			'\n\n- [#2](https://github.com/mheob/changeset-changelog/pull/2) ([@mheob](https://github.com/mheob)): An awesome feature, (resolves [#9](https://github.com/mheob/changeset-changelog/issues/9))\n',
 		);
 	});
 


### PR DESCRIPTION
Resolves #19

## Changes

- reformat changelog output
  - the new output looks like: "#PR (USER): MESSAGE"
- remove explicit return statements on every typescript functions
